### PR TITLE
Fixes #140: Corrected file extension handling for LiDAR data.

### DIFF
--- a/python/pandaset/annotations.py
+++ b/python/pandaset/annotations.py
@@ -92,7 +92,7 @@ class Cuboids(Annotation):
 
     @property
     def _data_file_extension(self) -> str:
-        return 'pkl.gz'
+        return 'pkl'
 
     @property
     def data(self) -> List[pd.DataFrame]:
@@ -203,7 +203,7 @@ class SemanticSegmentation(Annotation):
 
     @property
     def _data_file_extension(self) -> str:
-        return 'pkl.gz'
+        return 'pkl'
 
     @property
     def data(self) -> List[pd.DataFrame]:

--- a/python/pandaset/sensors.py
+++ b/python/pandaset/sensors.py
@@ -134,7 +134,7 @@ class Sensor:
 class Lidar(Sensor):
     @property
     def _data_file_extension(self) -> str:
-        return 'pkl.gz'
+        return 'pkl'
 
     @property
     def data(self) -> List[pd.DataFrame]:


### PR DESCRIPTION
This pull request addresses the issue described in #140, where the code expected `.pkl.gz` files but the actual data files are `.pkl`. The fix involves modifying the `_data_file_extension` method to return `.pkl`.


Thanks to [liuxinhai](https://github.com/liuxinhai) for suggesting the solution. I simply made those changes and opened a pull request. 